### PR TITLE
Important bug fix (wrong WAIT and cannonball explosions "ghosts")

### DIFF
--- a/src/main/java/Referee.java
+++ b/src/main/java/Referee.java
@@ -668,6 +668,7 @@ class Referee {
             int round = 0;
 
             while (round < getMaxRoundCount(2)) {
+                prepare(round);
                 out.println("###Input 0");
                 for (String line : getInputForPlayer(round, 0)) {
                     out.println(line);


### PR DESCRIPTION
Without prepare() there are 2 bugs:
1) WAIT repeat last command instead of wait
2) Whenever a ship is in a location where a cannonball has ever exploded - rum is decreased